### PR TITLE
Add check for undefined slug and blog

### DIFF
--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -2,10 +2,14 @@ import fs from "fs";
 import matter from "gray-matter";
 import Markdown from "markdown-to-jsx";
 import { getPostMetadata } from "@/helper/getPostMetadata";
+import { notFound } from "next/navigation";
 
 const getPortfolioContent = (slug: string) => {
   const folder = "src/posts";
   const file = `${folder}/${slug}.md`;
+  if (!slug || !fs.existsSync(file)) {
+    notFound()
+  }
   const content = fs.readFileSync(file, "utf8");
   const matterResult = matter(content);
   return matterResult;

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,10 @@
+const NotFound = () => {
+  return (
+    <div>
+      <h2 className="text-xl font-semibold">404 - Not Found</h2>
+      <p>Something went missing</p>
+    </div>
+  )
+}
+
+export default NotFound


### PR DESCRIPTION
Added check to ensure that the file exists and that the slug is defined before proceeding with the following method call:
```ts
const content = fs.readFileSync(file, "utf8");
``` 

resolve #6 